### PR TITLE
joyent/node-haproxy-log#1 reported malformed log line for entry from log file

### DIFF
--- a/lib/haproxy_log_parser.js
+++ b/lib/haproxy_log_parser.js
@@ -11,7 +11,7 @@ var VE = require('verror');
 var CLS_NOT_SPACE = '[^ ]+';
 var CLS_DIGITS = '[0-9]+';
 var CLS_IPADDR = '[:a-f0-9\\.]+';
-var CLS_DIGITS_NEG = '[-0-9]+';
+var CLS_DIGITS_OR_MINUS_ONE = '[0-9]+|-1';
 
 function
 build_matcher()
@@ -26,16 +26,6 @@ build_matcher()
 
 	var non = function (re) {
 		re_str += re;
-	};
-
-	var numseq = function () {
-		for (var i = 0; i < arguments.length; i++) {
-			if (i > 0) {
-				non('/');
-			}
-
-			group(CLS_DIGITS_NEG, arguments[i], 'number');
-		}
 	};
 
 	/*
@@ -60,18 +50,48 @@ build_matcher()
 	group('[^ /]+', 'backend_name');
 	non('/');
 	group(CLS_NOT_SPACE, 'server_name');
+
+	// The "Tq" and others are a haproxy 1.5-ism
+	// (https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#8.2.3)
+	// vs. "TR" in haproxy 1.7
+	// (https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#8.2.3)
 	non(' ');
-	numseq('Tq', 'Tw', 'Tc', 'Tr', 'Tt');
+	group(CLS_DIGITS_OR_MINUS_ONE, 'Tq', 'number');
+	non('/')
+	group(CLS_DIGITS_OR_MINUS_ONE, 'Tw', 'number');
+	non('/')
+	group(CLS_DIGITS_OR_MINUS_ONE, 'Tc', 'number');
+	non('/')
+	group(CLS_DIGITS_OR_MINUS_ONE, 'Tr', 'number');
+	non('/')
+	group('\\+?', 'Tt_logasap', 'boolean');
+	group(CLS_DIGITS, 'Tt', 'number');
+
 	non(' ');
-	group(CLS_DIGITS, 'status_code', 'number');
+	group(CLS_DIGITS_OR_MINUS_ONE, 'status_code', 'number');
 	non(' ');
 	group(CLS_DIGITS, 'bytes_read', 'number');
 	non(' - - ');
 	group('....', 'termination_state', 'termination_state');
+
 	non(' ');
-	numseq('actconn', 'feconn', 'beconn', 'srv_conn', 'retries');
+	group(CLS_DIGITS, 'actconn', 'number');
+	non('/')
+	group(CLS_DIGITS, 'feconn', 'number');
+	non('/')
+	group(CLS_DIGITS, 'beconn', 'number');
+	non('/')
+	group(CLS_DIGITS, 'src_conn', 'number');
+	non('/')
+	group('\\+?', 'retries_redispatch', 'boolean');
+	group(CLS_DIGITS, 'retries', 'number');
+
 	non(' ');
-	numseq('srv_queue', 'backend_queue');
+	group(CLS_DIGITS, 'srv_queue', 'number');
+	non('/')
+	group(CLS_DIGITS, 'backend_queue', 'number');
+
+
 	non(' "');
 	group('[^"]*', 'http_request');
 	non('"$');
@@ -187,7 +207,10 @@ HAProxyLogTransform.prototype._transform = function (l, _, done) {
 	var out = {};
 
 	if (!m) {
-		setImmediate(done, VE('malformed log line: "%s"', l));
+		var re = self.hlt_matcher.re;
+		setImmediate(done,
+		    VE('malformed log line: "%s" (does not match %s)',
+			l, re));
 		return;
 	}
 
@@ -210,6 +233,9 @@ HAProxyLogTransform.prototype._transform = function (l, _, done) {
 			break;
 		case 'ip':
 			out[g.n] = normalise_ip(v);
+			break;
+		case 'boolean':
+			out[g.n] = Boolean(v);
 			break;
 		default:
 			out[g.n] = m[g.i];


### PR DESCRIPTION
Improve parsing to handle:
- possible '-1' for status_code
- possible '-1' for some fields rather than the looser "possibly
  negative number"
- possible "+" on the 'Tt' and 'retries' fields